### PR TITLE
Fix issue #50 and check the right variable before adding body field when installing

### DIFF
--- a/config/webform.settings.json
+++ b/config/webform.settings.json
@@ -1,8 +1,8 @@
 {
     "_config_name": "webform.settings",
-    "webform_install_create_content_type": "TRUE",
-    "webform_install_add_body_field": "FALSE",
-    "webform_node_webform": "TRUE",
+    "webform_install_create_content_type": true,
+    "webform_install_add_body_field": false,
+    "webform_node_webform": true,
     "webform_blocks": [],
     "webform_tracking_mode": "cookie",
     "webform_allowed_tags": [
@@ -16,8 +16,8 @@
     "webform_default_from_name": "",
     "webform_default_from_address": "",
     "webform_default_subject": "Form submission from: [node:title]",
-    "webform_email_replyto": "TRUE",
-    "webform_email_html_capable": "FALSE",
+    "webform_email_replyto": 1,
+    "webform_email_html_capable": 0,
     "webform_default_format": "0",
     "webform_format_override": "0",
     "webform_email_select_max": "50",

--- a/webform.install
+++ b/webform.install
@@ -665,7 +665,7 @@ function webform_install() {
     );
     $webform_type = node_type_set_defaults($webform_type);
     node_type_save($webform_type);
-    if (config_get('webform.settings', 'webform_install_create_content_type')) {
+    if (config_get('webform.settings', 'webform_install_add_body_field')) {
       node_add_body_field($webform_type);
     }
     // Enable webform components by default on Webform nodes.


### PR DESCRIPTION
Making sure these variables match the values in Drupal 7 and also match Drupal 7 where it checks webform_install_add_body_field instead of webform_install_create_content_type before attempting to add a body field when installing.