### PR TITLE
Issue #96: Prevent PHP warnings during upgrade from Drupal 7.

### DIFF
--- a/webform.module
+++ b/webform.module
@@ -4738,7 +4738,10 @@ function webform_components($include_disabled = FALSE, $reset = FALSE) {
 
   if (!isset($components) || $reset) {
     $components = array();
-    $disabled = array_flip(webform_variable_get('webform_disabled_components'));
+    $disabled_components = webform_variable_get('webform_disabled_components');
+    if (is_array($disabled_components)) {
+      $disabled = array_flip();
+    }
     foreach (module_implements('webform_component_info') as $module) {
       $module_components = module_invoke($module, 'webform_component_info');
       foreach ($module_components as $type => $info) {

--- a/webform.module
+++ b/webform.module
@@ -4739,6 +4739,7 @@ function webform_components($include_disabled = FALSE, $reset = FALSE) {
   if (!isset($components) || $reset) {
     $components = array();
     $disabled_components = webform_variable_get('webform_disabled_components');
+    $disabled = array();
     if (is_array($disabled_components)) {
       $disabled = array_flip();
     }

--- a/webform.module
+++ b/webform.module
@@ -4741,7 +4741,7 @@ function webform_components($include_disabled = FALSE, $reset = FALSE) {
     $disabled_components = webform_variable_get('webform_disabled_components');
     $disabled = array();
     if (is_array($disabled_components)) {
-      $disabled = array_flip();
+      $disabled = array_flip($disabled_components);
     }
     foreach (module_implements('webform_component_info') as $module) {
       $module_components = module_invoke($module, 'webform_component_info');


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/webform/issues/96