### PR TITLE
Issue #231: Fix warning in CSV download when file isn’t present.

### DIFF
--- a/components/file.inc
+++ b/components/file.inc
@@ -566,7 +566,8 @@ function _webform_csv_headers_file($component, $export_options) {
  * Implements _webform_csv_data_component().
  */
 function _webform_csv_data_file($component, $export_options, $value) {
-  $file = webform_get_file($value[0]);
+  $fid = isset($value[0]) ? $value[0] : NULL;
+  $file = webform_get_file($fid);
   return empty($file->filename) ? array('', '') : array(webform_file_url($file->uri), (int) ($file->filesize / 1024));
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/webform/issues/231.