### PR TITLE
Update #default_value_pattern in select and grid components.

### DIFF
--- a/components/grid.inc
+++ b/components/grid.inc
@@ -100,7 +100,7 @@ function _webform_edit_grid($component) {
       '#key_type' => 'mixed',
       '#key_type_toggle' => t('Customize option keys (Advanced)'),
       '#key_type_toggled' => $component['extra']['custom_option_keys'],
-      '#default_value_pattern' => '^%.+\[.+\]$',
+      '#default_value_pattern' => '|^\[.*\]$',
       '#description' => t('<strong>Options to select across the top</strong>, such as "Poor" through "Excellent". Indicate the default to the left of the desired item. Use of only alphanumeric characters and underscores is recommended in keys.') . ' ' . theme('webform_token_help'),
     );
 

--- a/components/select.inc
+++ b/components/select.inc
@@ -136,7 +136,7 @@ function _webform_edit_select($component) {
       '#key_type' => 'mixed',
       '#key_type_toggle' => t('Customize keys (Advanced)'),
       '#key_type_toggled' => $component['extra']['custom_keys'],
-      '#default_value_pattern' => '^%.+\[.+\]$',
+      '#default_value_pattern' => '|^\[.*\]$',
       '#weight' => 1,
     );
 


### PR DESCRIPTION
Fixes #252 

When setting the default value manually to use tokens, the #default_value_pattern was using the old pattern so the token was not recognized and saved.